### PR TITLE
Add activation to accounts and password recovery

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,6 +56,14 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_cart
 
+  def log_in(user)
+    cookies.signed[:user_id] = {
+      value: user.id,
+      expires: 7.days.from_now,
+      httponly: true
+    }
+  end
+
   private
 
   def http_header_token

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,60 @@
+class PasswordResetsController < ApplicationController
+  before_action :get_user, only: %i[edit update]
+  before_action :valid_user, only: %i[edit update]
+  before_action :check_expiration, only: %i[edit update]
+
+  def new
+  end
+
+  def create
+    @user = User.find_by_email(password_reset_params[:email])
+    if @user
+      @user.create_reset_password_digest
+      @user.send_password_reset_email
+    end
+    redirect_to mail_sent_path
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_password_params)
+      log_in @user
+      flash[:success] = "Password has been reset."
+      redirect_to profile_path
+    else
+      flash.now[:warning] = "Password and confirmation password do not match. Please make sure they are identical and try again."
+      render "edit"
+    end
+  end
+
+  def mail_sent
+    render "mail_sent"
+  end
+
+  private
+
+  def get_user
+    @user = User.find_by(email: params[:email])
+  end
+
+  def valid_user
+    redirect_to root_url unless @user&.authenticated?(:reset_password, params[:id])
+  end
+
+  def check_expiration
+    if @user.password_reset_expired?
+      flash[:warning] = "Password reset has expired. Send new reset link ot your email."
+      redirect_to new_password_reset_url
+    end
+  end
+
+  def password_reset_params
+    params.require(:password_reset).permit(:email)
+  end
+
+  def user_password_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -30,7 +30,6 @@ class PasswordResetsController < ApplicationController
   end
 
   def mail_sent
-    render "mail_sent"
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,11 +3,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:email])
 
     if user&.authenticate(params[:password])
-      cookies.signed[:user_id] = {
-        value: user.id,
-        expires: 7.days.from_now,
-        httponly: true
-      }
+      log_in user
       merge_cart
       flash[:success] = "Logged in successfully!"
       redirect_to catalog_url

--- a/app/controllers/user_activations_controller.rb
+++ b/app/controllers/user_activations_controller.rb
@@ -1,0 +1,22 @@
+class UserActivationsController < ApplicationController
+  def new
+    user = current_user
+    user.update_activation_digest
+    user.send_activation_email
+    flash[:info] = "Activation link was send to your email!"
+    redirect_back fallback_location: profile_path
+  end
+
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      user.activate
+      log_in user
+      flash[:success] = "Account activated!"
+      redirect_to profile_path
+    else
+      flash[:warning] = "Invalid activation link"
+      redirect_to root_path
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :password)
+    params.require(:user).permit(:email, :password, :password_confirmation)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      flash[:success] = "User successfully created. Please log in."
-      redirect_to new_session_path
+      flash[:success] = "Account was successfully created!"
+      log_in @user
+      redirect_to root_path
     else
       render :new
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      flash[:success] = "Account was successfully created!"
       log_in @user
+      @user.send_activation_email
+      flash[:success] = "Account was successfully created!"
       redirect_to root_path
     else
       render :new

--- a/app/mailers/users_mailer.rb
+++ b/app/mailers/users_mailer.rb
@@ -1,0 +1,11 @@
+class UsersMailer < ApplicationMailer
+  def user_activation(user)
+    @link = edit_user_activation_url(user.activation_token, email: user.email)
+
+    mail(to: user.email, subject: "Store - Account activation")
+  end
+
+  def password_reset
+    mail(to: user.email, subject: "Store - Password recovery")
+  end
+end

--- a/app/mailers/users_mailer.rb
+++ b/app/mailers/users_mailer.rb
@@ -5,7 +5,9 @@ class UsersMailer < ApplicationMailer
     mail(to: user.email, subject: "Store - Account activation")
   end
 
-  def password_reset
+  def password_reset(user)
+    @link = edit_password_reset_url(user.reset_token, email: user.email)
+
     mail(to: user.email, subject: "Store - Password recovery")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,45 @@
 class User < ApplicationRecord
+  attr_accessor :activation_token
   has_many :orders
-  has_one :cart
+  has_one :cart, dependent: :destroy
   has_secure_password
+
+  validates :email, presence: true, uniqueness: true
+
+  before_create :create_activation_digest
 
   def admin?
     is_admin
+  end
+
+  def activated?
+    activated
+  end
+
+  def activate
+    update_attribute(:activated, true)
+    update_attribute(:activated_at, Time.zone.now)
+  end
+
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false if digest.nil?
+    BCrypt::Password.new(digest).is_password?(token)
+  end
+
+  def update_activation_digest
+    self.activation_token = Token.new_token
+    update_attribute(:activation_digest, Token.digest(self.activation_token))
+  end
+
+  def send_activation_email
+    UsersMailer.user_activation(self).deliver_now
+  end
+
+  private
+
+  def create_activation_digest
+    self.activation_token = Token.new_token
+    self.activation_digest = Token.digest(self.activation_token)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :activation_token
+  attr_accessor :activation_token, :reset_token
   has_many :orders
   has_one :cart, dependent: :destroy
   has_secure_password
@@ -32,8 +32,22 @@ class User < ApplicationRecord
     update_attribute(:activation_digest, Token.digest(self.activation_token))
   end
 
+  def create_reset_password_digest
+    self.reset_token = Token.new_token
+    update_attribute(:reset_password_digest,  Token.digest(reset_token))
+    update_attribute(:reset_password_sent_at, Time.zone.now)
+  end
+
+  def password_reset_expired?
+    reset_password_sent_at < 2.hours.ago
+  end
+
   def send_activation_email
     UsersMailer.user_activation(self).deliver_now
+  end
+
+  def send_password_reset_email
+    UsersMailer.password_reset(self).deliver_now
   end
 
   private

--- a/app/services/token.rb
+++ b/app/services/token.rb
@@ -1,0 +1,11 @@
+class Token
+  def self.new_token
+    SecureRandom.urlsafe_base64
+  end
+
+  def self.digest(string)
+    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
+                                                  BCrypt::Engine.cost
+    BCrypt::Password.create(string, cost: cost)
+  end
+end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,25 @@
+<div class="container my-auto">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <h2>Reset password</h2>
+
+      <%= form_for(@user, url: password_reset_path(params[:id]), class: "mt-4") do |form| %>
+        <%= hidden_field_tag :email, @user.email %>
+
+        <div class="mb-3">
+          <%= form.label :password, class: "form-label" %>
+          <%= form.password_field :password, class: "form-control" %>
+        </div>
+
+        <div class="mb-3">
+          <%= form.label :password_confirmation, class: "form-label" %>
+          <%= form.password_field :password_confirmation, class: "form-control" %>
+        </div>
+
+        <div class="actions mt-2">
+          <%= form.submit 'Update password', class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/password_resets/mail_sent.html.erb
+++ b/app/views/password_resets/mail_sent.html.erb
@@ -1,0 +1,4 @@
+<div class="container d-flex flex-column justify-content-center align-items-center my-auto">
+  <h3>Password recovery instractions was sent to your email</h3>
+  <%= link_to "Continue with Store", root_path, class: "btn btn-outline-success mt-3" %>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,18 @@
+<div class="container my-auto">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <h2>Forgot password</h2>
+
+      <%= form_for(:password_reset, url: password_resets_path, class: "mt-4") do |form| %>
+        <div class="mb-3">
+          <%= form.label :email, class: "form-label" %>
+          <%= form.email_field :email, class: "form-control" %>
+        </div>
+
+        <div class="actions mt-2">
+          <%= form.submit 'Send reset link', class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <%= render partial: "shared/activate_user", locals: { user: @user } %>
   <%= @user.email %>, Hi, this is your profile page.
   <hr>
   <% @user.orders.each do |order| %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container my-auto">
   <div class="row justify-content-center">
     <div class="col-md-6">
       <h2>Login</h2>
@@ -9,12 +9,13 @@
           <%= form.email_field :email, class: "form-control" %>
         </div>
 
-        <div class="mb-3">
+        <div class="mb-1">
           <%= form.label :password, class: "form-label" %>
           <%= form.password_field :password, class: "form-control" %>
         </div>
+        <%= link_to "Forgot password?", new_password_reset_path, class: "d-flex justify-content-end" %>
 
-        <div class="actions">
+        <div class="actions mt-2">
           <%= form.submit 'Login', class: "btn btn-primary" %>
         </div>
       <% end %>

--- a/app/views/shared/_activate_user.html.erb
+++ b/app/views/shared/_activate_user.html.erb
@@ -1,0 +1,6 @@
+<% unless user.activated? %>
+  <div class="container mb-3 p-2 border bg-light bg-gradient">
+    Please, activate your account! Click this button to send activation link to your email.
+    <%= link_to "Send activation link", new_user_activation_path, class: "btn btn-outline-info" %>
+  </div>
+<% end %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |key, value| %>
-  <div class="alert alert-<%= key %>">
+  <div class="alert alert-<%= key %> text-center">
     <% case key %>
     <% when "warning" %>
       <i class="fa-solid fa-triangle-exclamation"></i>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container my-auto">
   <div class="row justify-content-center">
     <div class="col-md-6">
       <h2 class="mb-4">Create a Brand new Account</h2>
@@ -23,6 +23,11 @@
         <div class="mb-3">
           <%= form.label :password, class: "form-label" %>
           <%= form.password_field :password, class: "form-control" %>
+        </div>
+
+        <div class="mb-3">
+          <%= form.label :password_confirmation, class: "form-label" %>
+          <%= form.password_field :password_confirmation, class: "form-control" %>
         </div>
 
         <div class="actions">

--- a/app/views/users_mailer/password_reset.html.erb
+++ b/app/views/users_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h1>User#password_reset</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+</p>

--- a/app/views/users_mailer/password_reset.html.erb
+++ b/app/views/users_mailer/password_reset.html.erb
@@ -1,5 +1,8 @@
-<h1>User#password_reset</h1>
-
-<p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
-</p>
+<div class="container">
+  <h1>Passwort recovery for your account on Store</h1>
+  <p>To change your password, please click the link below:</p>
+  <p><%= link_to "Change password", @link %></p>
+  <p>The link will expire in two hours.</p> 
+  <p>If you did not request a password reset, please ignore this email, and your password will remain unchanged.</p>
+  <p>Best regards,<br> Store</p>
+</div>

--- a/app/views/users_mailer/user_activation.html.erb
+++ b/app/views/users_mailer/user_activation.html.erb
@@ -1,0 +1,7 @@
+<div class="container">
+  <h1>Welcome to Store</h1>
+  <p>To activate your account, please click the link below:</p>
+  <p><%= link_to "Activate account", @link %></p>
+  <p>If you didn't request this, you can safely ignore this email.</p>
+  <p>Best regards,<br> Store</p>
+</div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,8 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   # users
   resources :users, only: %i[new create]
   resources :user_activations, only: %i[new edit]
+  resources :password_resets, only: %i[new create edit update]
+  get "/password_reset_success", to: "password_resets#mail_sent", as: "mail_sent"
   get "/profile", to: "profile#index", as: "profile"
   resources :sessions, only: %i[new create]
   resource :session, to: "sessions#destroy", only: %i[destroy], defaults: { id: nil }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,21 +1,24 @@
 Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
+  # catalog
   root to: "catalog#index"
   get "/catalog(/:category_slug)", to: "catalog#index", as: "catalog"
   resources :products, only: %i[show]
 
+  # users
   resources :users, only: %i[new create]
+  resources :user_activations, only: %i[new edit]
   get "/profile", to: "profile#index", as: "profile"
   resources :sessions, only: %i[new create]
   resource :session, to: "sessions#destroy", only: %i[destroy], defaults: { id: nil }
 
-
+  # carts and orders
   resource :cart, only: %i[show update]
-
   resources :orders, only: %i[new create]
   get "/orders/:uuid", to: "orders#show", as: "order_by_uuid"
 
+  # admin pages
   namespace "admin" do
     get "/", to: "home#index"
     resources :products

--- a/db/migrate/20240415133859_add_activation_to_users.rb
+++ b/db/migrate/20240415133859_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean, default: false
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/migrate/20240416104046_add_reset_password_to_users.rb
+++ b/db/migrate/20240416104046_add_reset_password_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetPasswordToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :reset_password_digest, :string
+    add_column :users, :reset_password_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_15_133859) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_16_104046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -89,6 +89,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_15_133859) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_password_digest"
+    t.datetime "reset_password_sent_at"
   end
 
   add_foreign_key "cart_products", "carts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_09_093247) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_15_133859) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -86,6 +86,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_09_093247) do
     t.boolean "is_admin"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "activation_digest"
+    t.boolean "activated", default: false
+    t.datetime "activated_at"
   end
 
   add_foreign_key "cart_products", "carts"

--- a/spec/mailers/previews/users_mailer_preview.rb
+++ b/spec/mailers/previews/users_mailer_preview.rb
@@ -1,0 +1,12 @@
+class UsersMailerPreview < ActionMailer::Preview
+  def user_activation
+    user = User.first
+    user.activation_token = Token.new_token
+    UsersMailer.user_activation(user)
+  end
+
+  def password_reset
+    user = User.first
+    UserMailer.password_reset(user)
+  end
+end

--- a/spec/mailers/previews/users_mailer_preview.rb
+++ b/spec/mailers/previews/users_mailer_preview.rb
@@ -7,6 +7,7 @@ class UsersMailerPreview < ActionMailer::Preview
 
   def password_reset
     user = User.first
-    UserMailer.password_reset(user)
+    user.reset_token = Token.new_token
+    UsersMailer.password_reset(user)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,5 +41,31 @@ RSpec.describe User, type: :model do
     it "#send_activation_email sends activation email" do
       expect { user.send_activation_email }.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
+
+    it "#send_password_reset_email sends password recovery email" do
+      user.create_reset_password_digest
+      expect { user.send_password_reset_email }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+
+  describe '#create_reset_password_digest' do
+    it 'should set reset_token, reset_password_digest, and reset_password_sent_at' do
+      user.create_reset_password_digest
+      expect(user.reset_token).to_not be_nil
+      expect(user.reset_password_digest).to_not be_nil
+      expect(user.reset_password_sent_at).to_not be_nil
+    end
+  end
+
+  describe '#password_reset_expired?' do
+    it 'should return true if reset_password_sent_at is older than 2 hours' do
+      user.reset_password_sent_at = 3.hours.ago
+      expect(user.password_reset_expired?).to eq(true)
+    end
+
+    it 'should return false if reset_password_sent_at is within 2 hours' do
+      user.reset_password_sent_at = 1.hour.ago
+      expect(user.password_reset_expired?).to eq(false)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  let(:user) { create(:user) }
+
+  describe "validations" do
+    let(:user2) { build(:user) }
+
+    it "is not valid with not unique email" do
+      user2.email = user.email
+      expect(user2).not_to be_valid
+    end
+  end
+
+  describe "instance methods" do
+    it "#admin? returns true if user is an admin" do
+      user.update(is_admin: true)
+      expect(user.admin?).to be true
+    end
+
+    it "#activated? returns true if user is activated" do
+      user.update(activated: true)
+      expect(user.activated?).to be true
+    end
+
+    it "#activate activates the user" do
+      user.activate
+      expect(user.activated?).to be true
+    end
+
+    it "#authenticated? returns true if the token matches the digest" do
+      expect(user.authenticated?(:activation, user.activation_token)).to be true
+    end
+
+    it "#update_activation_digest updates the activation digest" do
+      old_digest = user.activation_digest
+      user.update_activation_digest
+      expect(user.activation_digest).not_to eq(old_digest)
+    end
+
+    it "#send_activation_email sends activation email" do
+      expect { user.send_activation_email }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
Done:
- Added activation_digest and reset_password_digest to users
- Added requirement to activate email
- Added ability to change password
- Password recovery link expired in 2 hours
- Added users_mailer to send activation link and password recovery link (added user_mailer_preview)

User recieve a link with token and email provided to authorize user in system, check with digest stored in DB  